### PR TITLE
Remove the message blacklist added in #1

### DIFF
--- a/src/event.test.ts
+++ b/src/event.test.ts
@@ -34,21 +34,4 @@ describe('makeEvent', () => {
       })
     )
   })
-
-  test('should empty object if message_enum is blacklisted', () => {
-    expect(event.makeEvent({
-      message_enum: 42,
-      message: { sensitive: true },
-      from_device: true,
-      interface: 'StandardWebUSB'
-    })).toEqual(
-      expect.objectContaining({
-        date: expect.any(Number),
-        message_enum: 42,
-        message: {},
-        from_device: true,
-        interface: 'StandardWebUSB'
-      })
-    )
-  })
 })

--- a/src/event.ts
+++ b/src/event.ts
@@ -7,12 +7,6 @@ const { MessageType: {
   MESSAGETYPE_LOADDEVICE
 }} = Messages
 
-export const MSG_CONTENT_BLACKLIST = [
-  MESSAGETYPE_PASSPHRASEACK,
-  MESSAGETYPE_ENTROPYACK,
-  MESSAGETYPE_LOADDEVICE
-]
-
 export interface Event {
   message_type?: string
   message_enum: number
@@ -23,7 +17,6 @@ export interface Event {
 }
 
 export function makeEvent (e: Event): Event {
-  if (MSG_CONTENT_BLACKLIST.includes(e.message_enum)) e.message = {}
   return {
     message_type: messageNameRegistry[e.message_enum],
     date: Date.now(),


### PR DESCRIPTION
It breaks PassphraseAck's, and probably EntropyAck's too.  Client's *should* do
this themselves before logging, but we can't easily do it for them.  Leave
events alone for now.