### PR TITLE
Fix errors caused by overlapping reads

### DIFF
--- a/example/js/main.js
+++ b/example/js/main.js
@@ -137,9 +137,13 @@ window.connectWebUSB = function () {
       Object.keys(manager.keepkeys).forEach((deviceID) => {
         loggers[deviceID] = window.debug(deviceID)
       })
+      manager.deviceEvents.offAny()
       manager.deviceEvents.onAny((_, [deviceID, msg]) => {
         loggers[deviceID](msg)
       })
     })
-    .catch(console.error)
+    .catch(e => {
+      console.error('ConnectWebUSB Error')
+      console.error(String(e))
+    })
 }

--- a/package.json
+++ b/package.json
@@ -93,6 +93,7 @@
     "device-protocol": "git+https://git@github.com/KeepKey/device-protocol.git#4ee29339fb8a9c916bcba9079aebd5254a16df08",
     "eventemitter2": "^5.0.1",
     "google-protobuf": "^3.6.1",
+    "p-queue": "^3.0.0",
     "protobufjs": "^6.8.8",
     "rxjs": "^6.3.3"
   },
@@ -104,6 +105,7 @@
     "@types/google-protobuf": "^3.2.7",
     "@types/jest": "^23.3.2",
     "@types/node": "^10.11.0",
+    "@types/p-queue": "^3.0.0",
     "colors": "^1.3.2",
     "commitizen": "^3.0.0",
     "coveralls": "^3.0.2",


### PR DESCRIPTION
## Issue
Since `transferIn` is asynchronous, it's possible to have multiple async loops (see `webUsbDevice.read()`) to call `transferIn`, causing some packets to end up in the wrong read loop.

This manifests by a look expecting the first packet to have a header with a `messageLength`, but since the packet it receives is not really a first packet, but the middle of some other read, the read length is incorrect and causes an error when attempting to create a massively large array.

## Resolution
Use `p-queue` to add an async queue with a concurrency of 1 to only allow one message and response to the device at a time.

## Extra
This PR also simplifies some code around reading message length and concatenating packets.