### PR TITLE
WebUSBDevice: Return a Failure message if `read` throws

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,10 +57,12 @@
   },
   "jest": {
     "transform": {
-      ".(ts|tsx|js|json)": "ts-jest"
+      "^.+\\.js?$": "./tools/addDefaultTransform.js",
+      "\\.(ts|tsx)": "ts-jest"
     },
+    "transformIgnorePatterns": [],
     "testEnvironment": "node",
-    "testRegex": "(/__tests__/.*|\\.(test|spec))\\.(ts|tsx|js)$",
+    "testRegex": "(/__tests__/.*|\\.(test|spec))\\.(ts|tsx)$",
     "moduleFileExtensions": [
       "ts",
       "tsx",
@@ -69,6 +71,9 @@
       "json",
       "node"
     ],
+    "moduleNameMapper": {
+      "proto.json": "<rootDir>/src/__mocks__/proto.js"
+    },
     "coveragePathIgnorePatterns": [
       "/node_modules/",
       "/test/"

--- a/src/__mocks__/proto.js
+++ b/src/__mocks__/proto.js
@@ -1,0 +1,4 @@
+const json = require('fs').readFileSync(__dirname + '/../proto.json', { encoding: 'utf8'})
+
+module.exports = JSON.parse(json)
+// .default gets added by the addDefaultTransform function

--- a/src/webUSBDevice.test.ts
+++ b/src/webUSBDevice.test.ts
@@ -1,0 +1,21 @@
+import ByteBuffer from 'bytebuffer'
+import WebUSBDevice from './webUSBDevice'
+import Messages from './kkProto/messages_pb'
+import Types from './kkProto/types_pb'
+
+describe('WebUSBDevice', () => {
+  test('should return a Failure message if `read` throws an error', async () => {
+    const config = { usbDevice: {
+      transferIn: jest.fn().mockRejectedValueOnce(new Error('TEST'))
+    }, events: {} }
+    // @ts-ignore
+    const device = new WebUSBDevice(config)
+    const msg = new Messages.Cancel()
+    const response = new Messages.Failure()
+    response.setCode(Types.FailureType.FAILURE_UNEXPECTEDMESSAGE)
+    response.setMessage('Error: TEST')
+    const expected = ByteBuffer.wrap(response.serializeBinary())
+
+    await expect(device.sendRaw(msg.serializeBinary())).resolves.toEqual(expected)
+  })
+})

--- a/tools/addDefaultTransform.js
+++ b/tools/addDefaultTransform.js
@@ -1,0 +1,7 @@
+'use strict'
+
+module.exports = {
+  process(src) {
+    return src + '\n\nmodule.exports.default = module.exports;'
+  }
+}

--- a/tools/addDefaultTransform.js
+++ b/tools/addDefaultTransform.js
@@ -1,7 +1,18 @@
 'use strict'
 
 module.exports = {
+  /**
+   * Add a "default" property to all JS imports to make them compatible with rollup
+   *
+   * Rollup commonjs plugin converts all modules to do default exports, but ts-jest doesn't
+   * do that, so `import module from 'module'` fails because there is no ".default" property
+   *
+   * This just adds a "default" property to all imported JS files
+   *
+   * @param {string} src Source file provided by jest
+   * @returns {string}
+   */
   process(src) {
-    return src + '\n\nmodule.exports.default = module.exports;'
+    return src + '\n\nmodule.exports.default = module.exports.default || module.exports;'
   }
 }


### PR DESCRIPTION
### Description
If `read()` throws an error, we should return a valid Protobuf message that can be processed down the line as if the device had returned an actual Protobuf message.
* Use `try/catch` in `sendRaw` to catch errors and return a valid Protobuf `Failure` message

### Other changes:
* Add "addDefaultTransform" transform function to jest
  * rollup's commonjs module converts all commonjs module into ES6 modules with default exports
  * This allows `import module from 'module'` syntax to work
  * `ts-jest` does NOT do this, so the compiled TypeScript files are looking for `.default` when importing commonjs modules, resulting in an error
* Change jest config to only look for `.ts` test files to avoid running any `.js` files in `dist`
* Mock "proto.json" to also export `.default`
