### PR TITLE
Change `cancel` to bypass the message queue

### DIFF
--- a/example/index.html
+++ b/example/index.html
@@ -29,8 +29,14 @@
       <p>To seed the <code>window.keepkeyManager</code> with WebUSB devices, first pair a device, then click start.</p>
       <button class="button button-outline" onclick="window.keepkey.WebUSBDevice.requestPair()">Pair WebUSB Device</button>
       <button onclick="connectWebUSB()">START WEBUSB</button>
+      <div>
+        <button onclick="ping()">Ping</button>
+        <button onclick="pingWithButton()">Ping With Button</button>
+        <button onclick="pingWithPIN()">Ping With PIN</button>
+        <button onclick="cancelPending()">Send Cancel</button>
+      </div>
     </div>
-  
+
   </div>
   <script src="https://unpkg.com/debug@4.0.1/dist/debug.js"></script>
   <script src="https://code.jquery.com/jquery-3.3.1.min.js" integrity="sha256-FgpCb/KJQlLNfOu91ta32o/NMZxltwRo8QtmkMRdAu8=" crossorigin="anonymous"></script>

--- a/example/js/main.js
+++ b/example/js/main.js
@@ -147,3 +147,29 @@ window.connectWebUSB = function () {
       console.error(String(e))
     })
 }
+
+window.allPings = []
+
+const log = (name, p) => {
+  console.log('sending', name)
+  return window.allPings.push(p.then(res => console.log(`${name} response:`, res))
+    .catch(e => console.error(`${name} error:`, e)))
+}
+
+let pingCount = 0
+
+window.pingWithButton = function () {
+  log(`ping ${++pingCount} with button`, manager.exec('ping', { message: 'ping' + pingCount, buttonProtection: true }))
+}
+
+window.pingWithPIN = function () {
+  log(`ping ${++pingCount} with PIN`, manager.exec('ping', { message: 'ping' + pingCount, pinProtection: true }))
+}
+
+window.ping = function () {
+  log(`ping ${++pingCount}`, manager.exec('ping', { message: 'ping' + pingCount }))
+}
+
+window.cancelPending = function () {
+  log('cancelPending', window.keepkey.device.cancelPending())
+}

--- a/src/device.ts
+++ b/src/device.ts
@@ -84,6 +84,8 @@ export default abstract class Device {
 
   public abstract sendRaw (buffer: ByteBuffer): Promise<ByteBuffer>
 
+  public abstract cancelPending (): Promise<void>
+
   protected toMessageBuffer (msgTypeEnum: number, msg: jspb.Message): ByteBuffer {
     const messageBuffer = msg.serializeBinary()
 
@@ -111,5 +113,16 @@ export default abstract class Device {
     const msg = new MessageType()
     const reader = new jspb.BinaryReader(dataView.slice(9), 0, buff.limit - (9 + 2))
     return [typeID, MessageType.deserializeBinaryFromReader(msg, reader)]
+  }
+
+  protected static failureMessageFactory (e?: Error | string) {
+    const msg = new Messages.Failure()
+    msg.setCode(Types.FailureType.FAILURE_UNEXPECTEDMESSAGE)
+    if (typeof e === 'string') {
+      msg.setMessage(e)
+    } else {
+      msg.setMessage(String(e))
+    }
+    return ByteBuffer.wrap(msg.serializeBinary())
   }
 }

--- a/src/keepkey.ts
+++ b/src/keepkey.ts
@@ -138,11 +138,7 @@ export default class KeepKey {
   // Cancel aborts the last device action that required user interaction
   // It can follow a button request, passphrase request, or pin request
   public async cancel (): Promise<void> {
-    const cancel = new Messages.Cancel()
-    // send
-    await this.device.exchange(Messages.MessageType.MESSAGETYPE_CANCEL, cancel)
-
-    // Emit event to notify clients that an action has been cancelled
+    await this.device.cancelPending()
     this.device.events.emit('CANCEL_ACTION')
   }
 

--- a/src/webUSBDevice.test.ts
+++ b/src/webUSBDevice.test.ts
@@ -7,7 +7,7 @@ describe('WebUSBDevice', () => {
   test('should return a Failure message if `read` throws an error', async () => {
     const config = { usbDevice: {
       transferIn: jest.fn().mockRejectedValueOnce(new Error('TEST'))
-    }, events: {} }
+    }, events: { emit: jest.fn() } }
     // @ts-ignore
     const device = new WebUSBDevice(config)
     const msg = new Messages.Cancel()


### PR DESCRIPTION
* Change `KeepKey.cancel` to bypass the message queue
* Update the example page
  * Add buttons for Ping and Cancel to test the cancellation function
* Device now emits `read` and `write` events (useful for debugging all messages going to/from the device)
